### PR TITLE
XMLToCvs component - commons-lang3:3.13.0 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -386,7 +386,7 @@ dependencies {
     implementation "javax.cache:cache-api"
     implementation "org.hibernate:hibernate-core"
     implementation "com.zaxxer:HikariCP"
-    implementation "org.apache.commons:commons-lang3"
+    implementation "org.apache.commons:commons-lang3:3.13.0"
     implementation "commons-io:commons-io"
     implementation "javax.transaction:javax.transaction-api"
     implementation "org.ehcache:ehcache"


### PR DESCRIPTION
When using commons-text 1.11.0, commons-lang3 needs to be on version 3.13.0. by default was using 3.12.0