### PR TITLE
Spring boot 3 - jetty - property to set max head size was renamed

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -168,7 +168,7 @@ server:
       cookie:
         http-only: true
         max-age: 28800
-  max-http-header-size: 81920
+  max-http-request-header-size: 81920
   jetty:
     httpConfig:
       generateOrigin: true


### PR DESCRIPTION
oldPropertyKey
```
server.max-http-header-size
```
newPropertyKey:
```
server.max-http-request-header-size
```